### PR TITLE
Add script to extract and summarize metadata for all assets on lincbrain.org

### DIFF
--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -32,6 +32,7 @@ modalities = {'oct': 'PS-OCT',
 for dandiset in client.get_dandisets():
     latest_dandiset = dandiset.for_version('draft')
     for asset in latest_dandiset.get_assets():
+        print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]}", end='\r')
 
         metadata = asset.get_metadata()
         metadata_dict = metadata.model_dump(mode='json', exclude_none=True)

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -59,9 +59,9 @@ for dandiset in client.get_dandisets():
 modalities['unknown'] = 'Unknown'
 
 df_summary = pd.DataFrame(columns=["Modality",
-                           "Size (GB)",
-                           "Subjects", 
-                           "Extensions"])
+                                   "Size (GB)",
+                                   "Subjects", 
+                                   "Extensions"])
 
 for _, value in modalities.items():
     df_summary.loc[len(df_summary)] = [value,

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -19,7 +19,7 @@ df = pd.DataFrame(columns=["Dandiset",
                            "Path",
                            "Filename",
                            "Extension",
-                           "Source/Raw/Derived Data",
+                           "Directory", # Container directory (e.g. source data, raw data, derivatives)
                            'Size (bytes)'])
 
 modalities = {'oct': 'PS-OCT',
@@ -51,7 +51,7 @@ for dandiset in client.get_dandisets():
                             modality,
                             asset.path, 
                             asset.path.split('/')[-1],
-                            ''.join(Path(asset.path).suffixes),
+                            Path(asset.path).suffixes[0][1:],
                             asset.path.split('/')[0],
                             metadata_dict['contentSize']]
 

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -66,6 +66,6 @@ df_summary = pd.DataFrame(columns=["Modality",
 
 for key, value in modalities.items():
     df_summary.loc[len(df_summary)] = [value,
-                       sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1024**3),
+                       sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1000**3),
                        df[(df['Modality'] == value)]['Subject'].unique(),
                        df[(df['Modality'] == value)]['Extension'].unique()]

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -1,5 +1,4 @@
 from dandi.dandiapi import DandiAPIClient
-from dandi.dandiapi import RemoteDandiset
 import pandas as pd
 from pathlib import Path
 

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -23,11 +23,10 @@ df = pd.DataFrame(columns=["Dandiset",
                            'Size (bytes)'])
 
 modalities = {'oct': 'PS-OCT',
-                'df': 'Dark Field Microscopy',
-                'xpct': 'HiP-CT',
-                'dwi': 'DWI',
-                'fluo': 'LSM'
-                }
+              'df': 'Dark Field Microscopy',
+              'xpct': 'HiP-CT',
+              'dwi': 'DWI',
+              'fluo': 'LSM'}
 
 for dandiset in client.get_dandisets():
     latest_dandiset = dandiset.for_version('draft')
@@ -64,8 +63,8 @@ df_summary = pd.DataFrame(columns=["Modality",
                            "Subjects", 
                            "Extensions"])
 
-for key, value in modalities.items():
+for _, value in modalities.items():
     df_summary.loc[len(df_summary)] = [value,
-                       sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1000**3),
-                       df[(df['Modality'] == value)]['Subject'].unique(),
-                       df[(df['Modality'] == value)]['Extension'].unique()]
+                sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1000**3),
+                df[(df['Modality'] == value)]['Subject'].unique(),
+                df[(df['Modality'] == value)]['Extension'].unique()]

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -40,6 +40,9 @@ for dandiset in client.get_dandisets():
                 subject = part.split("sub-")[1].split('_')[0]
                 break
 
+        if subject == 'Unknown' and any(filename in asset.path.split('/')[-1].lower() for filename in ['dataset_description.json', 'participants.tsv', 'readme.md', 'samples.tsv']):
+            subject = 'n/a'
+
         modality = next((value for key, value in modalities.items() 
                          if key in asset.path.split('/')[-1].lower()), 
                          'Unknown')

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -19,7 +19,7 @@ df = pd.DataFrame(columns=["Dandiset",
                            "Path",
                            "Filename",
                            "Extension",
-                           "Directory", # Container directory (e.g. source data, raw data, derivatives)
+                           "Directory", # Top-level directory (e.g. source data, raw data, derivatives)
                            'Size (bytes)'])
 
 modalities = {'oct': 'PS-OCT',

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -13,8 +13,9 @@ modalities = {'oct': 'PS-OCT',
 def extract_assets():
     client = DandiAPIClient("https://api.lincbrain.org/api")
     client.dandi_authenticate()
+    dandisets = client.get_dandisets()
 
-    print(f"Processing {sum(1 for _ in client.get_dandisets())} Dandisets on lincbrain.org")
+    print(f"Processing {sum(1 for _ in dandisets)} Dandisets on lincbrain.org")
 
     df = pd.DataFrame(columns=["Dandiset",
                             "Version",
@@ -26,7 +27,7 @@ def extract_assets():
                             "Directory", # Top-level directory (e.g. source data, raw data, derivatives)
                             'Size (bytes)'])
 
-    for dandiset in client.get_dandisets():
+    for dandiset in dandisets:
         latest_dandiset = dandiset.for_version('draft')
         for asset in latest_dandiset.get_assets():
             print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]:<40}", end='\r')

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -1,6 +1,5 @@
 from dandi.dandiapi import DandiAPIClient
 from dandi.dandiapi import RemoteDandiset
-import numpy as np
 import pandas as pd
 from pathlib import Path
 

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -28,7 +28,7 @@ modalities = {'oct': 'PS-OCT',
 for dandiset in client.get_dandisets():
     latest_dandiset = dandiset.for_version('draft')
     for asset in latest_dandiset.get_assets():
-        print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]}", end='\r')
+        print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]}; Extension: {Path(asset.path).suffixes[0][1:]:<20}", end='\r')
 
         metadata = asset.get_metadata()
         metadata_dict = metadata.model_dump(mode='json', exclude_none=True)

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -23,7 +23,8 @@ modalities = {'oct': 'PS-OCT',
               'df': 'Dark Field Microscopy',
               'xpct': 'HiP-CT',
               'dwi': 'DWI',
-              'fluo': 'LSM'}
+              'fluo': 'LSM',
+              'photo': 'Blockface photo'}
 
 for dandiset in client.get_dandisets():
     latest_dandiset = dandiset.for_version('draft')

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -1,0 +1,54 @@
+from dandi.dandiapi import DandiAPIClient
+from dandi.dandiapi import RemoteDandiset
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+client = DandiAPIClient("https://api.lincbrain.org/api")
+client.dandi_authenticate()
+
+dandisets = []
+for data in client.paginate("/dandisets/"):
+    dandisets.append(RemoteDandiset.from_data(client, data))
+print(f"Number of Dandisets: {len(dandisets)}")
+
+df = pd.DataFrame(columns=["Dandiset",
+                           "Version",
+                           "Subject", 
+                           "Modality",
+                           "Path",
+                           "Filename",
+                           "Extension",
+                           "Source/Raw/Derived Data",
+                           'Size (bytes)'])
+
+for dandiset in client.get_dandisets():
+    latest_dandiset = dandiset.for_version('draft')
+    for asset in latest_dandiset.get_assets():
+
+        metadata = asset.get_metadata()
+        metadata_dict = metadata.model_dump(mode='json', exclude_none=True)
+
+        subject = 'Unknown'
+        for part in asset.path.split('/'):
+            if part.startswith("sub-"):
+                subject = part.split("sub-")[1].split('_')[0]
+                break
+
+        modality = next((value for key, value in {
+                        'oct': 'PS-OCT',
+                        'df': 'Dark Field Microscopy',
+                        'xpct': 'HiP-CT',
+                        'dwi': 'DWI',
+                        'fluo': 'LSM'
+                    }.items() if key in asset.path.split('/')[-1].lower()), 'Unknown')
+
+        df.loc[len(df)] = [latest_dandiset.identifier,
+                            latest_dandiset.version.identifier,
+                            subject,
+                            modality,
+                            asset.path, 
+                            asset.path.split('/')[-1],
+                            ''.join(Path(asset.path).suffixes),
+                            asset.path.split('/')[0],
+                            metadata_dict['contentSize']]

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -30,22 +30,24 @@ def extract_assets():
     for dandiset in dandisets:
         latest_dandiset = dandiset.for_version('draft')
         for asset in latest_dandiset.get_assets():
-            print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]:<40}", end='\r')
+            asset_split = asset.path.split('/')
+
+            print(f"Dandiset: {latest_dandiset}; Asset: {asset_split[-1]:<40}", end='\r')
 
             metadata = asset.get_metadata()
             metadata_dict = metadata.model_dump(mode='json', exclude_none=True)
 
             subject = 'Unknown'
-            for part in asset.path.split('/'):
+            for part in asset_split:
                 if part.startswith("sub-"):
                     subject = part.split("sub-")[1].split('_')[0]
                     break
 
-            if subject == 'Unknown' and any(filename in asset.path.split('/')[-1].lower() for filename in ['dataset_description.json', 'participants.tsv', 'readme.md', 'samples.tsv']):
+            if subject == 'Unknown' and any(filename in asset_split[-1].lower() for filename in ['dataset_description.json', 'participants.tsv', 'readme.md', 'samples.tsv']):
                 subject = 'n/a'
 
             modality = next((value for key, value in modalities.items() 
-                            if key in asset.path.split('/')[-1].lower()), 
+                            if key in asset_split[-1].lower()), 
                             'Unknown')
 
             suffix = Path(asset.path).suffixes[0][1:] if Path(asset.path).suffixes else ''
@@ -55,9 +57,9 @@ def extract_assets():
                                 subject,
                                 modality,
                                 asset.path, 
-                                asset.path.split('/')[-1],
+                                asset_split[-1],
                                 suffix,
-                                asset.path.split('/')[0],
+                                asset_split[0],
                                 metadata_dict['contentSize']]
 
     return df

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -7,6 +7,7 @@ from pathlib import Path
 client = DandiAPIClient("https://api.lincbrain.org/api")
 client.dandi_authenticate()
 
+# Create dataframe of all assets across all Dandisets
 dandisets = []
 for data in client.paginate("/dandisets/"):
     dandisets.append(RemoteDandiset.from_data(client, data))

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -29,7 +29,7 @@ modalities = {'oct': 'PS-OCT',
 for dandiset in client.get_dandisets():
     latest_dandiset = dandiset.for_version('draft')
     for asset in latest_dandiset.get_assets():
-        print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]}; Extension: {Path(asset.path).suffixes[0][1:]:<20}", end='\r')
+        print(f"Dandiset: {latest_dandiset}; Asset: {asset.path.split('/')[-1]:<40}", end='\r')
 
         metadata = asset.get_metadata()
         metadata_dict = metadata.model_dump(mode='json', exclude_none=True)
@@ -47,13 +47,15 @@ for dandiset in client.get_dandisets():
                          if key in asset.path.split('/')[-1].lower()), 
                          'Unknown')
 
+        suffix = Path(asset.path).suffixes[0][1:] if Path(asset.path).suffixes else ''
+
         df.loc[len(df)] = [latest_dandiset.identifier,
                             latest_dandiset.version.identifier,
                             subject,
                             modality,
                             asset.path, 
                             asset.path.split('/')[-1],
-                            Path(asset.path).suffixes[0][1:],
+                            suffix,
                             asset.path.split('/')[0],
                             metadata_dict['contentSize']]
 

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -55,6 +55,7 @@ for dandiset in client.get_dandisets():
                             ''.join(Path(asset.path).suffixes),
                             asset.path.split('/')[0],
                             metadata_dict['contentSize']]
+
 # Summarize data across modalities
 modalities['unknown'] = 'Unknown'
 

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -7,10 +7,7 @@ client = DandiAPIClient("https://api.lincbrain.org/api")
 client.dandi_authenticate()
 
 # Create dataframe of all assets across all Dandisets
-dandisets = []
-for data in client.paginate("/dandisets/"):
-    dandisets.append(RemoteDandiset.from_data(client, data))
-print(f"Number of Dandisets: {len(dandisets)}")
+print(f"Processing {sum(1 for _ in client.get_dandisets())} Dandisets on lincbrain.org")
 
 df = pd.DataFrame(columns=["Dandiset",
                            "Version",

--- a/extract-metadata.py
+++ b/extract-metadata.py
@@ -65,6 +65,6 @@ df_summary = pd.DataFrame(columns=["Modality",
 
 for _, value in modalities.items():
     df_summary.loc[len(df_summary)] = [value,
-                sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1000**3),
+                round(sum(df[(df['Modality'] == value)]['Size (bytes)'])/(1000**3),2),
                 df[(df['Modality'] == value)]['Subject'].unique(),
                 df[(df['Modality'] == value)]['Extension'].unique()]


### PR DESCRIPTION
- [x] Create a list of all assets across all Dandisets on lincbrain.org with the following metadata fields: Dandiset, Dandiset version, subject, modality, asset path, filename, extension, top-level directory, asset size
- [x] Summarize data across modalities
  - Calculate total size
  - List subjects
  - List file extensions

@ayendiki @satra @aaronkanzer The next pull request will add the information collected in this script to a dashboard.  Is there any other information that you would like to see on the first version of the dashboard?  